### PR TITLE
Mc/refactor rest api data

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "cypress": "cypress open"
+    "cypress": "cypress open",
+    "sass": "sass src/Sass:src/Css --watch --no-source-map"
   },
   "eslintConfig": {
     "extends": [
@@ -42,6 +43,7 @@
     ]
   },
   "devDependencies": {
-    "cypress": "^10.10.0"
+    "cypress": "^10.10.0",
+    "sass": "^1.55.0"
   }
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -22,7 +22,7 @@ const App = () => {
   }
 
   const getDistrict = (addressObject) => {
-    console.log('ADDRESS OBJECT', addressObject)
+    // console.log('ADDRESS OBJECT', addressObject)
     return fetch(`https://reportcard-rails.herokuapp.com/api/v1/district_data`, {
       method: "POST",
       headers: {
@@ -32,7 +32,7 @@ const App = () => {
     })
     .then(response => response.json())
     .then(result => {
-      console.log('RESULT', result)
+      // console.log('RESULT', result)
       setDistrictData(result)
       navigate('/district-info')
     })

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -12,7 +12,7 @@ const App = () => {
 
   const [districtData, setDistrictData] = useState({})
   const [userCredentials, setUserCredentials] = useState({})
-  
+
   const submitLogin = () => {
     setUserCredentials(userCredentials)
   }
@@ -20,10 +20,10 @@ const App = () => {
   const searchForAddress = (newAddressQuery) => {
     getDistrict(newAddressQuery)
   }
-  
+
   const getDistrict = (addressObject) => {
     console.log('ADDRESS OBJECT', addressObject)
-    fetch(`https://reportcard-rails.herokuapp.com/api/v1/district_data`, {
+    return fetch(`https://reportcard-rails.herokuapp.com/api/v1/district_data`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
@@ -36,16 +36,18 @@ const App = () => {
       setDistrictData(result)
       navigate('/district-info')
     })
-
+    .catch(function (error) {
+      console.log(error);
+    });
   }
-  
+
   return (
     <div className="App">
       <NavBar />
 
       <Routes>
         <Route exact path='/' element={
-          <UserLoginPage submitLogin={submitLogin}/>
+          <UserLoginPage submitLogin={submitLogin} />
         } />
 
         <Route path='/home' element={

--- a/src/components/DistrictInfoPage/DistrictInfoPage.js
+++ b/src/components/DistrictInfoPage/DistrictInfoPage.js
@@ -10,10 +10,10 @@ const DistrictInfoPage = ({ districtData }) => {
     const navigate = useNavigate()
     console.log('DISTRICT DATA', districtData)
     const newReportCard = districtData.data.attributes.map(attribute => {
-        console.log("districtData", districtData)
+        console.log("attribute", attribute)
         return (
             <ReportCard 
-                id = {districtData.data.id}
+                id = {districtData.lea_id}
                 key = {uuidV4()}
                 studentTeacherRatio = {attribute.student_teacher_ratio}
                 perStudentExpenditure={attribute.per_student_expenditure}

--- a/src/components/DistrictInfoPage/DistrictInfoPage.js
+++ b/src/components/DistrictInfoPage/DistrictInfoPage.js
@@ -17,8 +17,6 @@ const DistrictInfoPage = ({ districtData }) => {
                 key = {uuidV4()}
                 studentTeacherRatio = {attribute.student_teacher_ratio}
                 perStudentExpenditure={attribute.per_student_expenditure}
-                teacherSalaryInfo={attribute.teacher_salary_info}
-                studentPopulationSize={attribute.student_population_size}
                 numberOfSchoolsInDistrict={attribute.number_of_schools_in_district}
             />
         )

--- a/src/components/DistrictInfoPage/DistrictInfoPage.js
+++ b/src/components/DistrictInfoPage/DistrictInfoPage.js
@@ -8,9 +8,9 @@ import {  useNavigate } from 'react-router-dom';
 
 const DistrictInfoPage = ({ districtData }) => {
     const navigate = useNavigate()
-    console.log('DISTRICT DATA', districtData)
+    // console.log('DISTRICT DATA', districtData)
     const newReportCard = districtData.data.attributes.map(attribute => {
-        console.log("attribute", attribute)
+        // console.log("attribute", attribute)
         return (
             <ReportCard 
                 id = {districtData.lea_id}

--- a/src/components/ReportCard/ReportCard.js
+++ b/src/components/ReportCard/ReportCard.js
@@ -7,8 +7,6 @@ const ReportCard = ({ studentTeacherRatio, perStudentExpenditure, teacherSalaryI
         <div className='report-card'>
             <p className='card-bubble'>{studentTeacherRatio}</p>
             <p className='card-bubble'>{perStudentExpenditure}</p>
-            <p className='card-bubble'>{teacherSalaryInfo}</p>
-            <p className='card-bubble'>{studentPopulationSize}</p>
             <p className='card-bubble'>{numberOfSchoolsInDistrict}</p>
         </div>
     )

--- a/src/components/ReportCard/ReportCard.js
+++ b/src/components/ReportCard/ReportCard.js
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types'
 const ReportCard = ({ studentTeacherRatio, perStudentExpenditure, teacherSalaryInfo, studentPopulationSize, numberOfSchoolsInDistrict }) => {
     return (
         <div className='report-card'>
-            {studentTeacherRatio}
-            {perStudentExpenditure}
-            {teacherSalaryInfo}
-            {studentPopulationSize}
-            {numberOfSchoolsInDistrict}
+            <p className='card-bubble'>{studentTeacherRatio}</p>
+            <p className='card-bubble'>{perStudentExpenditure}</p>
+            <p className='card-bubble'>{teacherSalaryInfo}</p>
+            <p className='card-bubble'>{studentPopulationSize}</p>
+            <p className='card-bubble'>{numberOfSchoolsInDistrict}</p>
         </div>
     )
 }

--- a/src/components/ReportCard/ReportCard.scss
+++ b/src/components/ReportCard/ReportCard.scss
@@ -2,11 +2,17 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-top: 12em;
+}
+
+.card-bubble {
     box-sizing: border-box;
     border: 3px solid black;
     border-radius: 6em;
     padding: 1em;
     height: 5em;
     width: 5em;
-    margin-top: 12em;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }

--- a/src/components/UserLoginForm/UserLoginForm.js
+++ b/src/components/UserLoginForm/UserLoginForm.js
@@ -3,7 +3,7 @@ import './UserLoginForm.scss'
 import { v4 as uuidV4 } from "uuid"
 
 const UserLoginForm = ({ submitLogin }) => {
-    console.log(submitLogin)
+    // console.log(submitLogin)
     const [userName, setUserName] = useState("")
     const [password, setPassword] = useState("")
 
@@ -29,7 +29,7 @@ const UserLoginForm = ({ submitLogin }) => {
             password: setPassword(`${this.userName}2022`)
         }
         submitLogin(userLoginCredentials)
-        console.log(this.userLoginCredentials.userName)
+        // console.log(this.userLoginCredentials.userName)
         clearInputs()
     }
 


### PR DESCRIPTION
## Pull request type
Describe the purpose of this PR(other):
- [Add .catch to API call and return](https://github.com/reportcard-org/reportcard-fe/commit/dbe642e71e59bcf572fec0bb9687a0e192e3976d)
- [Add styling for ReportCard for data visibility](https://github.com/reportcard-org/reportcard-fe/commit/7d06b68cd91c88496ba43822b34c689d32b20193)
- [Remove nonexistent data from report card](https://github.com/reportcard-org/reportcard-fe/commit/cf4057901c9b00ad7ba7a9a1cba0969b5bc4e273)
- Previous `JSON contract` + `DistrictInfoPage` + `ReportCard`  were rendering a new card for each of the indices of the `array` when using `.map()`

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe):

🎉 Hooray! 🎉

![Screen Shot 2022-10-20 at 4 15 03 PM](https://user-images.githubusercontent.com/101746747/197076452-a4f1e052-60ef-497b-81e6-57e1d97ec78d.png)


## Problem/feature

What problem are you trying to solve?
- Previous `JSON contract` + `DistrictInfoPage` + `ReportCard`  were rendering a new card for each of the indices of the `array` when using `.map()`

## Solution

_How did you solve the problem?_
- met with @alepbloyd to adjust `JSON contract` for FE

Any other comments, questions or concerns?
- `teacher_salary_info` & `student_population_size` are no longer a naming convention in the dataset, need to identify which naming conventions are used in the new dataset for this data

## Checklist
- [x] Code compiles correctly
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

